### PR TITLE
Break reference cycle on py3

### DIFF
--- a/pyparsing.py
+++ b/pyparsing.py
@@ -3603,26 +3603,30 @@ class MatchFirst(ParseExpression):
     def parseImpl( self, instring, loc, doActions=True ):
         maxExcLoc = -1
         maxException = None
-        for e in self.exprs:
-            try:
-                ret = e._parse( instring, loc, doActions )
-                return ret
-            except ParseException as err:
-                if err.loc > maxExcLoc:
-                    maxException = err
-                    maxExcLoc = err.loc
-            except IndexError:
-                if len(instring) > maxExcLoc:
-                    maxException = ParseException(instring,len(instring),e.errmsg,self)
-                    maxExcLoc = len(instring)
+        try:
+            for e in self.exprs:
+                try:
+                    ret = e._parse( instring, loc, doActions )
+                    return ret
+                except ParseException as err:
+                    if err.loc > maxExcLoc:
+                        maxException = err
+                        maxExcLoc = err.loc
+                except IndexError:
+                    if len(instring) > maxExcLoc:
+                        maxException = ParseException(instring,len(instring),e.errmsg,self)
+                        maxExcLoc = len(instring)
 
-        # only got here if no expression matched, raise exception for match that made it the furthest
-        else:
-            if maxException is not None:
-                maxException.msg = self.errmsg
-                raise maxException
+            # only got here if no expression matched, raise exception for match that made it the furthest
             else:
-                raise ParseException(instring, loc, "no defined alternatives to match", self)
+                if maxException is not None:
+                    maxException.msg = self.errmsg
+                    raise maxException
+                else:
+                    raise ParseException(instring, loc, "no defined alternatives to match", self)
+        finally:
+            # Break reference cycle
+            maxException = None
 
     def __ior__(self, other ):
         if isinstance( other, basestring ):


### PR DESCRIPTION
Python 3 exception objects have a `__traceback__` attribute that refers back to the current frame,  causing a reference cycle.

This change clears the `maxException` local thus breaking the reference cycle.

See also: https://sourceforge.net/p/pyparsing/mailman/message/27189609/